### PR TITLE
Updated vagrant configuration for the refactor of the python api

### DIFF
--- a/puppet/modules/etl/manifests/init.pp
+++ b/puppet/modules/etl/manifests/init.pp
@@ -1,19 +1,42 @@
 class etl
 {
 
+		exec { "install-numpy": 
+			command    => "sudo pip install numpy",
+			require    => [Package["python-pip"], Package['build-essential'], Package['python-dev']],
+			timeout    => 5000
+		}
+
     exec { 'install-pandas':
     	command	    => "sudo pip install pandas==0.12",
     	require	    => [Package['python-pip'], Package['build-essential'], Package['python-dev']],
 			timeout     => 10000
     }
 
-		package { "python-scipy":
-			ensure      => present,
-			require     => [Exec['apt-get update'], Exec['install-pandas']]
+		exec { "install-flask":
+			command    => "sudo pip install flask",
+			require    => [Package['python-pip']],
+		}
+
+		exec { "install-pymongo":
+			command    => "sudo pip install pymongo",
+			require    => [Package["python-pip"]]
+		}
+
+		exec { "install-mysql-connector":
+			command    => "sudo pip install mysql-connector-python",
+			require    => [Package["python-pip"]]
 		}
 	
     exec { "install-apscheduler":
         command     => "pip install apscheduler",
         require     => [Package['python-pip']] 
     }
+		
+		/* Uncomment and remove "install-mysql-connector" once postgres migration complete
+		exec { "install-psycopg2":
+			command    => "sudo pip install psycopg2",
+			require    => [Package["build-essential"], Package["python-dev"], Package['python-pip']]
+		}
+		*/
 }

--- a/puppet/modules/other/manifests/init.pp
+++ b/puppet/modules/other/manifests/init.pp
@@ -21,14 +21,6 @@ class other
             require => Exec['pecl-oauth-install'],
     }
 
-    exec 
-    { 
-        'etl-setup':
-            command => '/var/www/vagrant/src/scripts/etl-setup.sh',
-            require => Package['python-setuptools'],
-            onlyif  => 'test -f /var/www/siv-v3/api-data/setup.py',
-    }
-
     exec { "setup-twine-tools":
         command => 'sudo ln -sf /var/www/vagrant/src/scripts/twine-tools /usr/bin/twine-tools'
     }
@@ -99,13 +91,6 @@ class other
             ensure  => present,
             source  => "/var/www/vagrant/puppet/templates/config.json",
             require => Package['apache2'],
-    }
-
-    file { "/var/www/logs":
-	ensure => directory,
-	owner => "www-data",
-	group => "www-data",
-	mode => 777
     }
    
     file 

--- a/puppet/modules/python/manifests/init.pp
+++ b/puppet/modules/python/manifests/init.pp
@@ -2,16 +2,11 @@ class python
 {      
 
     package { 'python':
-	ensure	    => present,
-	require	    => Exec['apt-get update'] 
-    }
-    
-    package { 'python-pip':
 			ensure	    => present,
 			require	    => Exec['apt-get update'] 
     }
     
-    package { 'python-setuptools':
+    package { 'python-pip':
 			ensure	    => present,
 			require	    => Exec['apt-get update'] 
     }

--- a/puppet/templates/etl.wsgi
+++ b/puppet/templates/etl.wsgi
@@ -1,5 +1,0 @@
-import sys
-sys.path.insert(0, '/var/www/siv-v3/api-data/ETL')
-
-from etl import create_app
-application = create_app()

--- a/puppet/templates/siv.ini
+++ b/puppet/templates/siv.ini
@@ -395,12 +395,16 @@ master_password =
 
 ; General ETL Settings
 [etl_general]
-debug = False
-api_debug = False
-log_path = /var/www/logs
-request_loggin = False
-threading = False
-log_finished_report = False
+; Whether or not the application outputs debugging info to the console/log
+debug = True
+; number of threads to allow the ETL Direct api to spawn
+ETL_WORKERS = 4
+; number of threads to allow the Data API to spawn for jobs
+DATA_WORKERS = 4
+; Location of the data folder
+DATA_FOLDER=/var/www/siv-v3/assets/data
+; URL location of the data folder
+DATA_URL=http://192.168.50.4/siv-v3/assets/data
 
 ; ETL Security items
 [etl_security]
@@ -430,32 +434,6 @@ ignored_indicators = reportdate
     bEdited2
     REPORT_ID
 
-; Settings for Flask ETL that tells it which sub-applications to load
-[modules]
-job = /etl
-status = /status
-performance = /performance
-intelligence = /intelligence
-quality = /quality
-api = /api
-anomalous = /anomalous
-
-; Settings for anomaly detector
-[anomalous]
-FULL_DURATION = 3
-ANOMALY_DUMP = /var/www/flaskapps/dump/anomalies.json
-ANALYZER_PROCESSES = 5
-STALE_PERIOD = 500
-MIN_TOLERABLE_LENGTH = 1
-MAX_TOLERABLE_BOREDOM = 5
-
-ALGORITHMS = mean_subtraction_cumulation
-    simple_stddev_from_moving_average
-    stddev_from_moving_average
-    grubbs
-    histogram_bins
-
-CONSENSUS = 5
 
 ; Settings pertaining to the Job Scheduler system in Python, mainly used for the queue
 [scheduler]
@@ -465,8 +443,8 @@ SCHEDULER_ENABLED = True
 SCHEDULER_INTERVAL = 30
 ; The number of josb the scheduler will take on in each run
 SCHEDULER_TACKLE = 8
-; Where the scheduler logs to
-SCHEDULER_LOG_FILE = /var/www/logs/sheduler_log.log
+; Number of threads to use for processing queue items
+SCHEDULER_WORKERS = 2
 
 [client]
 ; Root path of the application

--- a/puppet/templates/vhost
+++ b/puppet/templates/vhost
@@ -16,9 +16,9 @@
 		allow from all
 	</Directory>
 	
-	WSGIDaemonProcess api-data processes=1 maximum-requests=500 threads=2
-        WSGIScriptAlias /api-data /var/www/siv-v3/api-data/ETL/etl.wsgi
-	<Directory /var/www/siv-v3/api-data/ETL>
+	WSGIDaemonProcess api-data processes=2 maximum-requests=500 threads=2
+	WSGIScriptAlias /api-data /var/www/siv-v3/api-data/twine/twine.wsgi
+	<Directory /var/www/siv-v3/api-data/twine>
 		WSGIProcessGroup api-data
 		WSGIApplicationGroup %{GLOBAL}
 		Order deny,allow

--- a/src/scripts/etl-setup.sh
+++ b/src/scripts/etl-setup.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-echo "change directory to /var/www/flaskapps/etl/"
-cd /var/www/siv-v3/api-data
-
-python setup.py install
-


### PR DESCRIPTION
This update will allow the new python api to run, however there will be issues in Explore when trying to connect to the api, as well as with ETL and some other components as the syntax for interacting with the API and Queue API have changed. Updates for the client-side are coming soon to rectify this.
