### PR TITLE
3.25 Featuremod 334 Queue Email

### DIFF
--- a/puppet/templates/siv.ini
+++ b/puppet/templates/siv.ini
@@ -220,30 +220,20 @@ tokens = postgres_twine.users.tokens,0,id
 ; email settings
 
 ; variables are as follows:
-; 'send' 1/0 - whether to send emails
 ; 'host' hostname of mail server
 ; 'port' post to connect on
 ; 'username' username
 ; 'password' password
-; 'protocol' email protocol
 ; 'sender' sender
-; 'recipients' email addresses for test recipients (comma delimited)
+; 'test_recipient' email address for test recipient which overrides recipients in queue
 ; 'site_name' site name to use in emails
 
-; PHP API specific:
-; send, site_name, protocol, port, crlf, newline
-
-; Python API specific:
-; sender
-
-send = 0
 host = ssl://smtp.googlemail.com
 port = 465
 username = locsis.webhis@gmail.com
 password = --locsiswebhispwd--
-protocol = smtp
 sender = username
-recipients = jeff@jdu-it.co.uk,mark.yarmoshuk@gmail.com
+test_recipient =
 site_name = twine
 
 ;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
- removed "send" setting from siv.ini (controlled by disabling scheduler).
- removed "protocol" setting from siv.ini (not used).
- changed "recipients" to "test_recipient".
